### PR TITLE
Make tests run with Rake 0.8.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    rake-hooks (1.2.2)
-      rake (>= 0.9.2)
+    rake-hooks (1.2.3)
+      rake (= 0.8.7)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    rake (0.9.2.2)
+    rake (0.8.7)
 
 PLATFORMS
   ruby

--- a/rake-hooks.gemspec
+++ b/rake-hooks.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "rake"
+  s.add_runtime_dependency "rake", "0.8.7"
 
   s.add_development_dependency "bundler"
 end

--- a/test/test_rake_hooks.rb
+++ b/test/test_rake_hooks.rb
@@ -25,6 +25,9 @@ class TestRakeHooks < Test::Unit::TestCase
   end
 
   def setup
+    if Rake::TaskManager.respond_to?(:record_task_metadata=)
+      Rake::TaskManager.record_task_metadata = true
+    end
     Store.clean
   end
 

--- a/test/test_rake_hooks.rb
+++ b/test/test_rake_hooks.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'test/unit'
 require 'rake'
 require 'rake/hooks'
@@ -24,7 +25,6 @@ class TestRakeHooks < Test::Unit::TestCase
   end
 
   def setup
-    Rake::TaskManager.record_task_metadata = true
     Store.clean
   end
 


### PR DESCRIPTION
It looks like you recently did some work to make sure this worked on multiple versions of Rake. I just tried running the tests with Rake 0.8.7 and there were a few minor problems. I have tweaked it so that the tests now work under both Rake 0.8.7 and 0.9.2.2.
