### PR TITLE
Make tests runnable under Rake 0.8.7

### DIFF
--- a/test/test_rake_hooks.rb
+++ b/test/test_rake_hooks.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'test/unit'
 require 'rake'
 require 'rake/hooks'
@@ -24,7 +25,9 @@ class TestRakeHooks < Test::Unit::TestCase
   end
 
   def setup
-    Rake::TaskManager.record_task_metadata = true
+    if Rake::TaskManager.respond_to?(:record_task_metadata=)
+      Rake::TaskManager.record_task_metadata = true
+    end
     Store.clean
   end
 


### PR DESCRIPTION
It looks like you recently did some work to make sure this worked on multiple versions of Rake. I just tried running the tests with Rake 0.8.7 and there were a few minor problems. I have tweaked it so that the tests now work under both Rake 0.8.7 and 0.9.2.2.
