### PR TITLE
Honor the prerequisites of hooked tasks.

### DIFF
--- a/lib/rake/hooks.rb
+++ b/lib/rake/hooks.rb
@@ -3,7 +3,7 @@ module Rake::Hooks
     task_names.each do |task_name|
       old_task = Rake.application.instance_variable_get('@tasks').delete(task_name.to_s)
       desc old_task.full_comment
-      task task_name do
+      task task_name => old_task.prerequisites do
         new_task.call
         old_task.invoke
       end
@@ -14,7 +14,7 @@ module Rake::Hooks
     task_names.each do |task_name|
       old_task = Rake.application.instance_variable_get('@tasks').delete(task_name.to_s)
       desc old_task.full_comment
-      task task_name do
+      task task_name => old_task.prerequisites do
         old_task.invoke
         new_task.call
       end

--- a/test/test_rake_hooks.rb
+++ b/test/test_rake_hooks.rb
@@ -25,6 +25,7 @@ class TestRakeHooks < Test::Unit::TestCase
 
   def setup
     Rake::TaskManager.record_task_metadata = true
+    Rake::Task.clear
     Store.clean
   end
 

--- a/test/test_rake_hooks.rb
+++ b/test/test_rake_hooks.rb
@@ -91,4 +91,8 @@ class TestRakeHooks < Test::Unit::TestCase
   def execute(task_name)
     Rake::Task[task_name].execute
   end
+
+  def invoke(task_name)
+    Rake::Task[task_name].invoke
+  end
 end

--- a/test/test_rake_hooks.rb
+++ b/test/test_rake_hooks.rb
@@ -88,6 +88,42 @@ class TestRakeHooks < Test::Unit::TestCase
     assert_equal "this is my task", Rake::Task[:my_task2].full_comment
   end
 
+  def test_save_prerequisites_with_after_tasks
+    task :a       do ; end
+    task :b => :a do ; end
+
+    assert_equal ['a'], Rake::Task[:b].prerequisites
+    after :b do ; end
+    assert_equal ['a'], Rake::Task[:b].prerequisites
+  end
+
+  def test_save_prerequisites_with_before_tasks
+    task :a       do ; end
+    task :b => :a do ; end
+
+    assert_equal ['a'], Rake::Task[:b].prerequisites
+    before :b do ; end
+    assert_equal ['a'], Rake::Task[:b].prerequisites
+  end
+
+  def test_prerequisites_run_before_before_tasks
+    task   :a       do Store << "a" ; end
+    task   :b => :a do Store << "b" ; end
+    before :b       do Store << "-BEFORE-" ; end
+
+    invoke(:b)
+    assert_equal "a-BEFORE-b", Store.to_s
+  end
+
+  def test_prerequisites_run_before_after_tasks
+    task  :a       do Store << "a"       ; end
+    task  :b => :a do Store << "b"       ; end
+    after :b       do Store << "-AFTER-" ; end
+
+    invoke(:b)
+    assert_equal "ab-AFTER-", Store.to_s
+  end
+
   def execute(task_name)
     Rake::Task[task_name].execute
   end


### PR DESCRIPTION
The current method of hooking tasks breaks two things about prerequisites of the task it hooks.
1. The set of prerequisites returned from `Rake::Task#prerequisites` is cleared by `before` and `after`. While the invocation of the hooked task will still run those prerequisites, any other code that explicitly checks `#prerequisites` will break.
2. It runs the `before` hook _before_ the prerequisites. I would argue that the before hook should be run immediately before the task being hooked, NOT before the prerequisites. Otherwise, there may be some unpredictable ordering. For example, if the prerequisite had already been run by another dependent task, then the prerequisite happens before the `before` block. But if it had not been previously run, then the prerequisite happens _after_ the `before` block.

Consider a more real-world case in the Rails world:

``` ruby
task :foo => :environment do
  # ...something that requires the Rails environment has been loaded
end

before :foo do
  # ...something that you want just before :foo, that also requires environment
end
```

In this case, `rake foo` will fail because it needs the `:environment` task to have been run first. However, this bug could go unnoticed if the `:foo` task was commonly run by another task that happens to also require the environment.

The current ordering of tasks is not predictable and can cause unexpected problems like this.
## Solution

I have patched `hook.rb` to copy the prerequisites from the `old_task` to the `new_task`. This solves both the above problems. When the `new_task` is invoked, it's prerequisites are checked and invoked if necessary, _then_ the before hook is called. Also, this keeps `Rake::Task#prerequisites` intact.

I have added some test cases to cover this (which fail without these patches), and have tested it with Rake 0.8.7 and Rake 0.9.2.2.

Cheers,
-Scott
