### PR TITLE
Add options to after_hook in order to ignore exceptions

### DIFF
--- a/lib/rake/hooks.rb
+++ b/lib/rake/hooks.rb
@@ -11,11 +11,19 @@ module Rake::Hooks
   end
 
   def after(*task_names, &new_task)
+    options = task_names.last.is_a?(Hash) ? task_names.pop : {}
+    ignore_exceptions = options.delete(:ignore_exceptions) || false
+
     task_names.each do |task_name|
       old_task = Rake.application.instance_variable_get('@tasks').delete(task_name.to_s)
       desc old_task.full_comment
       task task_name => old_task.prerequisites do
-        old_task.invoke
+        begin
+          old_task.invoke
+        rescue
+          raise unless ignore_exceptions
+        end
+
         new_task.call
       end
     end

--- a/test/test_rake_hooks.rb
+++ b/test/test_rake_hooks.rb
@@ -126,6 +126,28 @@ class TestRakeHooks < Test::Unit::TestCase
     assert_equal "ab-AFTER-", Store.to_s
   end
 
+  def test_raise_exceptions_on_after_task
+    task  :a do raise "ERROR"      ; end
+    after :a do Store << "-AFTER-" ; end
+
+    assert_raise RuntimeError do
+      invoke(:a)
+    end
+
+    assert_equal "", Store.to_s
+  end
+
+  def test_ignore_exceptions_on_after_task
+    task  :a                             do raise "ERROR"     ; end
+    after :a, :ignore_exceptions => true do Store << "-AFTER-"; end
+
+    assert_nothing_raised RuntimeError do
+      invoke(:a)
+    end
+
+    assert_equal "-AFTER-", Store.to_s
+  end
+
   def execute(task_name)
     Rake::Task[task_name].execute
   end


### PR DESCRIPTION
In one of my projects, I needed to execute the after_hook task even if exceptions occured in the hooked task. So, I added support for options in after_hook in order to ignore exceptions when needed.
