### PR TITLE
Pass current task to after/before block

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ You can also pass more than one task and each task will be setup with the
 callback
 
 ```ruby
-before :say_hello, :say_goodbye do
-  puts "Hi !"
+before :say_hello, :say_goodbye do |t|
+  puts "Before #{t}"
 end
 ```
 

--- a/lib/rake/hooks.rb
+++ b/lib/rake/hooks.rb
@@ -4,7 +4,7 @@ module Rake::Hooks
       old_task = Rake.application.instance_variable_get('@tasks').delete(task_name.to_s)
       desc old_task.full_comment
       task task_name => old_task.prerequisites do
-        new_task.call
+        new_task.call(old_task)
         old_task.invoke
       end
     end
@@ -24,7 +24,7 @@ module Rake::Hooks
           raise unless ignore_exceptions
         end
 
-        new_task.call
+        new_task.call(old_task)
       end
     end
   end


### PR DESCRIPTION
In situations where a `before` or `after` block is run on multiple tasks, it can be helpful to know which task is actually about to run. For example, I want something to run before any task:

```ruby
before *Rake.application.top_level_tasks do |t|
  puts "Excuse me, I am about to run #{t}..."
end
after *Rake.application.top_level_tasks do |t|
  puts "...Thank you for letting me run #{t}"
end
```

This mimics how you can get the current task from within a task

```ruby
task :sometask do |t|
  puts "I am running #{t}"
end
```
